### PR TITLE
Fix fetching messages

### DIFF
--- a/fbchat/_models/_message.py
+++ b/fbchat/_models/_message.py
@@ -164,7 +164,7 @@ class Message:
             >>> message.text
             "The message text"
         """
-        message_info = await self.thread._forced_fetch(self.id).get("message")
+        message_info = (await self.thread._forced_fetch(self.id)).get("message")
         return MessageData._from_graphql(self.thread, message_info)
 
     @staticmethod


### PR DESCRIPTION
```
File "/home/kvgx12/projekty/WiertarBot/.venv/lib64/python3.8/site-packages/fbchat/_models/_message.py", line 167, in fetch
    message_info = await self.thread._forced_fetch(self.id).get("message")
AttributeError: 'coroutine' object has no attribute 'get'
```
