### PR TITLE
always set trust_env=True

### DIFF
--- a/fbchat/_session.py
+++ b/fbchat/_session.py
@@ -173,9 +173,7 @@ def session_factory(domain: str, user_agent: Optional[str] = None) -> aiohttp.Cl
         http_proxy = urllib.request.getproxies()["http"]
     except KeyError:
         http_proxy = None
-    return aiohttp.ClientSession(connector=(ProxyConnector.from_url(http_proxy)
-                                            if ProxyConnector and http_proxy
-                                            else None),
+    return aiohttp.ClientSession(trust_env=True,
                                  headers={
                                      "Referer": f"https://www.{domain}/",
                                      "User-Agent": user_agent or f"fbchat-asyncio/{__version__}",


### PR DESCRIPTION
trust_env=True

https://docs.aiohttp.org/en/stable/client_reference.html

Should force aiohttp to always obey HTTP_PROXY env var