### PR TITLE
Fix "Got empty response when trying to check login"

### DIFF
--- a/fbchat/_session.py
+++ b/fbchat/_session.py
@@ -507,7 +507,7 @@ class Session:
 
         # Make a request to the main page to retrieve ServerJSDefine entries
         try:
-            r = await session.get(prefix_url(domain, "/"), allow_redirects=False, headers={
+            r = await session.get(prefix_url(domain, "/"), allow_redirects=True, headers={
                 "Accept": "text/html",
             })
         except aiohttp.ClientError as e:


### PR DESCRIPTION
Fixes https://github.com/tulir/mautrix-facebook/issues/109

Seems like trying to hit `/` results in a 302 redirect,
leading me to some chat (https://www.messenger.com/t/XXXXXXXX/).

Allowing redirects seems to make the bridge work again.

I guess this potentially makes the `if len(html) == 0` check (below) potentially
useless, since it's now unlikely to receive an empty response.